### PR TITLE
fix(ontology): honor path_policy for DAG path distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 “Undirected shortest path on the transitive reduction” is fast but can produce unintuitive “cross-branch” detours. Offer an alternative:
 
-path_policy="up_down": distance = depth(a)+depth(b) − 2*depth(best_LCA) (uses DAG LCA policy), i.e., the tree path induced by the chosen LCA. It’s semantically tighter and cheap if you have ancestor bitsets.
+path_policy="spanning_tree": distance = depth(a)+depth(b) − 2*depth(best_LCA) (uses DAG LCA policy), i.e., the tree path induced by the chosen LCA. It’s semantically tighter and cheap if you have ancestor bitsets.
 
 
 **Distances/Similarities** (pickable by `metric`):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,65 @@ def simple_ontology():
 
 
 @pytest.fixture
+def dag_cross_branch_shortcut() -> tuple[dict[str, dict[str, str]], list[tuple[str, str]]]:
+    r"""
+    DAG where undirected shortest path is shorter than LCA up/down path.
+
+          root
+         /    \
+        a      b
+        |      |
+        u      v
+         \    /
+           z
+
+    d_spanning_tree(u, v) = 4 via root
+    d_undirected_tr(u, v) = 2 via z
+    """
+    nodes = {node_id: {"name": node_id.upper()} for node_id in ["root", "a", "b", "u", "v", "z"]}
+    edges = [
+        ("root", "a"),
+        ("root", "b"),
+        ("a", "u"),
+        ("b", "v"),
+        ("u", "z"),
+        ("v", "z"),
+    ]
+    return nodes, edges
+
+
+@pytest.fixture
+def dag_with_redundant_edge() -> tuple[dict[str, dict[str, str]], list[tuple[str, str]]]:
+    r"""
+    DAG with an explicit transitive edge.
+
+    root -> a -> b -> c -> z
+    root -> x -> y ----^
+                   ^
+                   |
+                   b -> z  (redundant transitive edge via b -> c -> z)
+
+    For distance between b and y:
+      - raw edges shortest path is 2 (b-z-y),
+      - transitive-reduction shortest path is 3 (b-c-z-y).
+    """
+    nodes = {
+        node_id: {"name": node_id.upper()} for node_id in ["root", "a", "b", "c", "x", "y", "z"]
+    }
+    edges = [
+        ("root", "a"),
+        ("a", "b"),
+        ("b", "c"),
+        ("c", "z"),
+        ("root", "x"),
+        ("x", "y"),
+        ("y", "z"),
+        ("b", "z"),
+    ]
+    return nodes, edges
+
+
+@pytest.fixture
 def krippendorff_data():
     """
     Canonical 12-item dataset from Krippendorff (1980).

--- a/tests/test_ontology_distance.py
+++ b/tests/test_ontology_distance.py
@@ -97,6 +97,31 @@ def test_dag_ambiguous_lca():
     assert ont.get_distance("c1", "c2") == 2
 
 
+def test_path_policy_undirected_tr_uses_undirected_shortest_path(
+    dag_cross_branch_shortcut,
+):
+    nodes, edges = dag_cross_branch_shortcut
+    ont = Ontology.build("v1", nodes, edges, path_policy="undirected_tr")
+
+    # Old LCA up/down formula would yield 4, but undirected shortest path via z is 2.
+    assert ont.get_distance("u", "v", metric="path") == 2
+
+
+def test_path_policy_spanning_tree_keeps_lca_formula(dag_cross_branch_shortcut):
+    nodes, edges = dag_cross_branch_shortcut
+    ont = Ontology.build("v1", nodes, edges, path_policy="spanning_tree")
+
+    assert ont.get_distance("u", "v", metric="path") == 4
+
+
+def test_undirected_tr_ignores_redundant_edges(dag_with_redundant_edge):
+    nodes, edges = dag_with_redundant_edge
+    ont = Ontology.build("v1", nodes, edges, path_policy="undirected_tr")
+
+    # Raw edges would give 2 via b-z-y; transitive reduction removes b-z.
+    assert ont.get_distance("b", "y", metric="path") == 3
+
+
 def test_deep_linear_ontology_builds_without_recursion_error():
     """A deep chain should build without hitting Python recursion depth limits."""
     node_count = 1500

--- a/tests/test_ontology_semantic.py
+++ b/tests/test_ontology_semantic.py
@@ -1,5 +1,5 @@
-import pytest
 import math
+import pytest
 from pyrator.ontology.core import Ontology
 
 


### PR DESCRIPTION
## Summary
- honor path_policy in Ontology.get_distance(..., metric="path")
- implement undirected_tr as shortest undirected path over transitive-reduction edges
- keep spanning_tree on existing LCA/depth formula
- add DAG fixtures/tests for cross-branch shortest path and redundant-edge TR behavior
- align README policy wording from up_down to spanning_tree

## Verification
- uv run pytest tests/test_ontology_distance.py tests/test_ontology_core_additional.py tests/test_ontology_semantic.py -v
- uv run pytest tests/test_config.py -k path_policy -v
