### PR TITLE
fix: eliminate quadratic DuckDB streaming scans

### DIFF
--- a/pyrator/data/backends/duckdb.py
+++ b/pyrator/data/backends/duckdb.py
@@ -7,7 +7,7 @@ offering SQL-based data processing with direct API calls.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Iterator, Set
+from typing import Any, Iterator
 
 from pyrator.data.backends.base import BaseBackend
 from pyrator.data.registry import BackendRegistry
@@ -18,6 +18,8 @@ from pyrator.types import FrameLike
 class DuckDBBackend(BaseBackend):
     """DuckDB-based data backend."""
 
+    backend_module = "duckdb"
+
     def _create_backend(self):
         import duckdb
 
@@ -27,15 +29,88 @@ class DuckDBBackend(BaseBackend):
     def name(self) -> str:
         return "duckdb"
 
-    def capabilities(self) -> Set[str]:
+    def capabilities(self) -> set[str]:
         return {"csv", "parquet", "streaming"}
+
+    def _duckdb_backend(self) -> Any:
+        backend = self._backend
+        if backend is None:
+            raise RuntimeError("duckdb backend is unavailable; install duckdb to use this backend.")
+        return backend
+
+    @staticmethod
+    def _escape_sql_literal(value: str) -> str:
+        """Escape single quotes for SQL string literals."""
+        return value.replace("'", "''")
+
+    @staticmethod
+    def _fetch_df_chunk(fetch_df_chunk: Any, chunk_size: int) -> Any:
+        """Call DuckDB chunk fetch with compatibility across API variants."""
+        try:
+            return fetch_df_chunk(chunk_size)
+        except TypeError:
+            pass
+
+        try:
+            return fetch_df_chunk(rows_per_batch=chunk_size)
+        except TypeError:
+            pass
+
+        try:
+            return fetch_df_chunk(chunk_size=chunk_size)
+        except TypeError:
+            pass
+
+        return fetch_df_chunk()
+
+    @staticmethod
+    def _fetch_record_batch(fetch_record_batch: Any, chunk_size: int) -> Any:
+        """Call DuckDB record-batch fetch with compatibility across API variants."""
+        try:
+            return fetch_record_batch(chunk_size)
+        except TypeError:
+            pass
+
+        try:
+            return fetch_record_batch(rows_per_batch=chunk_size)
+        except TypeError:
+            pass
+
+        return fetch_record_batch()
+
+    def _iter_relation_chunks(self, relation: Any, chunk_size: int) -> Iterator[Any]:
+        """Yield relation data in chunks without repeated SQL re-scans."""
+        fetch_df_chunk = getattr(relation, "fetch_df_chunk", None)
+        if callable(fetch_df_chunk):
+            while True:
+                batch = self._fetch_df_chunk(fetch_df_chunk, chunk_size)
+                if len(batch) == 0:
+                    return
+                yield batch
+
+        fetch_record_batch = getattr(relation, "fetch_record_batch", None)
+        if callable(fetch_record_batch):
+            reader = self._fetch_record_batch(fetch_record_batch, chunk_size)
+            for record_batch in reader:
+                batch = record_batch.to_pandas()
+                if len(batch) > 0:
+                    yield batch
+            return
+
+        # Fallback for older APIs: one-pass materialization with local slicing.
+        batch = relation.df()
+        if len(batch) == 0:
+            return
+        for start in range(0, len(batch), chunk_size):
+            yield batch.iloc[start : start + chunk_size]
 
     def load_csv(self, path: Path, sep: str = ",", **kwargs: Any) -> FrameLike:
         """Load CSV file using DuckDB."""
         from loguru import logger
 
         logger.debug(f"Loading CSV with DuckDB: {path.name}")
-        return self._backend.read_csv(path, sep=sep).df()
+        backend = self._duckdb_backend()
+        return backend.read_csv(path, sep=sep).df()
 
     def load_jsonl(self, path: Path, **kwargs: Any) -> FrameLike:
         """Load JSONL file using DuckDB.
@@ -49,8 +124,9 @@ class DuckDBBackend(BaseBackend):
 
         # Try to read as newline-delimited JSON
         try:
+            backend = self._duckdb_backend()
             # DuckDB can parse JSON lines with read_json_auto
-            return self._backend.read_json_auto(str(path)).df()
+            return backend.read_json_auto(str(path)).df()
         except Exception as e:
             raise RuntimeError(f"DuckDB JSONL support failed: {e}")
 
@@ -59,8 +135,9 @@ class DuckDBBackend(BaseBackend):
         from loguru import logger
 
         logger.debug(f"Loading Parquet with DuckDB: {path.name}")
+        backend = self._duckdb_backend()
         # Use direct API call, note .pl() returns Polars DataFrame
-        return self._backend.read_parquet(path).pl()
+        return backend.read_parquet(path).pl()
 
     def scan_csv(
         self, path: Path, chunk_size: int, sep: str = ",", **kwargs: Any
@@ -70,43 +147,26 @@ class DuckDBBackend(BaseBackend):
 
         logger.debug(f"Scanning CSV with DuckDB: {path.name}")
 
+        backend = self._duckdb_backend()
         chunk_size_int = int(chunk_size)
-        offset = 0
-
-        while True:
-            query = (
-                f"SELECT * FROM read_csv('{path}', header=True, sep='{sep}') "
-                f"LIMIT {chunk_size_int} OFFSET {offset}"
-            )
-            batch = self._backend.sql(query).df()
-            if len(batch) == 0:
-                break
-            yield batch
-            offset += chunk_size_int
+        path_sql = self._escape_sql_literal(str(path))
+        sep_sql = self._escape_sql_literal(sep)
+        query = f"SELECT * FROM read_csv('{path_sql}', header=True, sep='{sep_sql}')"
+        relation = backend.sql(query)
+        yield from self._iter_relation_chunks(relation, chunk_size_int)
 
     def scan_jsonl(self, path: Path, chunk_size: int, **kwargs: Any) -> Iterator[FrameLike]:
-        """Scan JSONL file in chunks using DuckDB.
-
-        Uses LIMIT/OFFSET with row_number to stream without loading entire file.
-        """
+        """Scan JSONL file in chunks using DuckDB."""
         from loguru import logger
 
         logger.debug(f"Scanning JSONL with DuckDB: {path.name}")
 
+        backend = self._duckdb_backend()
         chunk_size_int = int(chunk_size)
-        offset = 0
-
-        while True:
-            query = (
-                f"SELECT * FROM ("
-                f"SELECT *, row_number() OVER() as _rn FROM read_json_auto('{path}')"
-                f") WHERE _rn > {offset} AND _rn <= {offset + chunk_size_int}"
-            )
-            batch = self._backend.sql(query).df()
-            if len(batch) == 0:
-                break
-            yield batch
-            offset += chunk_size_int
+        path_sql = self._escape_sql_literal(str(path))
+        query = f"SELECT * FROM read_json_auto('{path_sql}')"
+        relation = backend.sql(query)
+        yield from self._iter_relation_chunks(relation, chunk_size_int)
 
     def scan_parquet(self, path: Path, chunk_size: int, **kwargs: Any) -> Iterator[FrameLike]:
         """Scan Parquet file in chunks using DuckDB."""
@@ -114,13 +174,9 @@ class DuckDBBackend(BaseBackend):
 
         logger.debug(f"Scanning Parquet with DuckDB: {path.name}")
 
+        backend = self._duckdb_backend()
         chunk_size_int = int(chunk_size)
-        offset = 0
-
-        while True:
-            query = f"SELECT * FROM read_parquet('{path}') LIMIT {chunk_size_int} OFFSET {offset}"
-            batch = self._backend.sql(query).pl()
-            if len(batch) == 0:
-                break
-            yield batch
-            offset += chunk_size_int
+        path_sql = self._escape_sql_literal(str(path))
+        query = f"SELECT * FROM read_parquet('{path_sql}')"
+        relation = backend.sql(query)
+        yield from self._iter_relation_chunks(relation, chunk_size_int)


### PR DESCRIPTION
## Summary
- replace SQL LIMIT/OFFSET pagination in DuckDB CSV/JSONL/Parquet scanners with relation chunk iteration
- remove JSONL row_number() OVER() paging path to avoid forced materialization
- add regression assertions ensuring no OFFSET or ROW_NUMBER appears in scan SQL

## Test Plan
- [x] uv run pytest tests/test_duckdb_backend.py -v