### PR TITLE
perf: add lightweight backend availability prechecks

### DIFF
--- a/pyrator/data/backends/base.py
+++ b/pyrator/data/backends/base.py
@@ -7,6 +7,7 @@ ensuring consistent behavior and interface compliance.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from importlib.util import find_spec
 from typing import Any
 
 from pyrator.data.spi import DataBackend
@@ -14,6 +15,8 @@ from pyrator.data.spi import DataBackend
 
 class BaseBackend(DataBackend, ABC):
     """Abstract base class for data backends."""
+
+    backend_module: str | None = None
 
     def __init__(self) -> None:
         """Initialize backend state without crashing on missing optional deps."""
@@ -25,6 +28,16 @@ class BaseBackend(DataBackend, ABC):
         except ImportError:
             self._backend = None
             self._available = False
+
+    @classmethod
+    def is_available_class(cls) -> bool:
+        """Cheap class-level dependency probe without backend instantiation."""
+        if cls.backend_module is None:
+            return True
+        try:
+            return find_spec(cls.backend_module) is not None
+        except (ImportError, ValueError):
+            return False
 
     @abstractmethod
     def _create_backend(self) -> Any:

--- a/pyrator/data/backends/pandas.py
+++ b/pyrator/data/backends/pandas.py
@@ -20,6 +20,8 @@ from pyrator.types import FrameLike
 class PandasBackend(BaseBackend):
     """Pandas-based data backend."""
 
+    backend_module = "pandas"
+
     def _create_backend(self) -> Any:
         import pandas
 

--- a/pyrator/data/backends/polars.py
+++ b/pyrator/data/backends/polars.py
@@ -18,6 +18,8 @@ from pyrator.types import FrameLike
 class PolarsBackend(BaseBackend):
     """Polars-based data backend."""
 
+    backend_module = "polars"
+
     def _create_backend(self):
         import polars
 

--- a/pyrator/data/backends/pyarrow.py
+++ b/pyrator/data/backends/pyarrow.py
@@ -19,6 +19,8 @@ from pyrator.types import FrameLike
 class PyArrowBackend(BaseBackend):
     """PyArrow-based data backend."""
 
+    backend_module = "pyarrow.parquet"
+
     def _create_backend(self):
         import pyarrow.parquet as pq
 


### PR DESCRIPTION
## Summary
- add class-level backend availability probing and module-spec checks before backend instantiation
- add registry probe/instance caches to avoid repeated heavy backend initialization during selection
- keep capability-based backend selection behavior and add tests for probe skipping and cache reuse

## Test Plan
- [x] uv run pytest tests/test_registry.py -v