### PR TITLE
fix: loader fallback and pandas streaming capability handling

### DIFF
--- a/pyrator/data/backends/pandas.py
+++ b/pyrator/data/backends/pandas.py
@@ -32,12 +32,9 @@ class PandasBackend(BaseBackend):
         return "pandas"
 
     def capabilities(self) -> set[str]:
-        base_capabilities = {"csv", "jsonl", "parquet"}
-        try:
-            __import__("pyarrow.parquet")
-        except ImportError:
-            return base_capabilities
-        return base_capabilities | {"streaming"}
+        # Pandas supports chunked CSV/JSONL scans without pyarrow.
+        # Parquet scanning still validates pyarrow at call time.
+        return {"csv", "jsonl", "parquet", "streaming"}
 
     def _pandas_backend(self) -> Any:
         """Return initialized pandas module or raise a dependency error."""

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -38,6 +38,20 @@ else:
     pl = DummyPl  # type: ignore
 
 
+def _has_pandas_parquet_engine() -> bool:
+    """Return True when pandas can write parquet in this environment."""
+    if not has_pandas():
+        return False
+
+    try:
+        from pandas.io.parquet import get_engine
+
+        get_engine("auto")
+        return True
+    except Exception:
+        return False
+
+
 class TestValidateFile:
     """Test the _validate_file utility function."""
 
@@ -125,6 +139,8 @@ class TestLoadAny:
         """Test load_any with Parquet file."""
         if not has_pandas():
             pytest.skip("Pandas not available for creating test parquet")
+        if not _has_pandas_parquet_engine():
+            pytest.skip("No parquet engine available for pandas in this environment")
 
         parquet_file = tmp_path / "test.parquet"
         df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
@@ -279,6 +295,8 @@ class TestLoadParquet:
         """Test basic Parquet loading."""
         if not has_pandas():
             pytest.skip("Pandas not available for creating test parquet")
+        if not _has_pandas_parquet_engine():
+            pytest.skip("No parquet engine available for pandas in this environment")
 
         parquet_file = tmp_path / "test.parquet"
         df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
@@ -293,6 +311,8 @@ class TestLoadParquet:
         """Test Parquet loading preferring polars."""
         if not has_polars() or not has_pandas():
             pytest.skip("Polars and Pandas not available")
+        if not _has_pandas_parquet_engine():
+            pytest.skip("No parquet engine available for pandas in this environment")
 
         parquet_file = tmp_path / "test.parquet"
         df = pd.DataFrame({"a": [1], "b": [2]})
@@ -308,6 +328,8 @@ class TestLoadParquet:
         """Test Parquet loading preferring pandas."""
         if not has_pandas():
             pytest.skip("Pandas not available")
+        if not _has_pandas_parquet_engine():
+            pytest.skip("No parquet engine available for pandas in this environment")
 
         parquet_file = tmp_path / "test.parquet"
         df = pd.DataFrame({"a": [1], "b": [2]})
@@ -323,6 +345,8 @@ class TestLoadParquet:
 
         if not has_pandas() or not has_duckdb():
             pytest.skip("Pandas and DuckDB not available")
+        if not _has_pandas_parquet_engine():
+            pytest.skip("No parquet engine available for pandas in this environment")
 
         parquet_file = tmp_path / "test.parquet"
         df = pd.DataFrame({"a": [1], "b": [2]})
@@ -513,6 +537,8 @@ class TestScanParquet:
         """Test basic Parquet scanning."""
         if not has_pandas():
             pytest.skip("Pandas not available for creating test parquet")
+        if not _has_pandas_parquet_engine():
+            pytest.skip("No parquet engine available for pandas in this environment")
 
         parquet_file = tmp_path / "test.parquet"
         df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
@@ -528,6 +554,8 @@ class TestScanParquet:
         """Test Parquet scanning preferring polars."""
         if not has_polars() or not has_pandas():
             pytest.skip("Polars and Pandas not available")
+        if not _has_pandas_parquet_engine():
+            pytest.skip("No parquet engine available for pandas in this environment")
 
         parquet_file = tmp_path / "test.parquet"
         df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
@@ -549,6 +577,8 @@ class TestScanParquet:
 
         if not has_pandas():
             pytest.skip("Pandas not available for creating test parquet")
+        if not _has_pandas_parquet_engine():
+            pytest.skip("No parquet engine available for pandas in this environment")
 
         parquet_file = tmp_path / "test.parquet"
         df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})


### PR DESCRIPTION
## Summary
Fixes #7 by making data loader backend selection resilient to missing optional dependencies and by correcting pandas streaming capability advertisement.

### What changed
- `pyrator/data/loaders.py`
  - `prefer=` backend selection now falls back to capability-based auto selection when the preferred backend is unavailable.
  - If preferred backend exists but lacks required capabilities, it falls back with a warning.
- `pyrator/data/backends/pandas.py`
  - `capabilities()` now always includes `streaming` for CSV/JSONL/parquet API surface.
  - Parquet scanner still performs runtime `pyarrow` validation at call time.
- `tests/test_loaders.py`
  - Added `_has_pandas_parquet_engine()` helper.
  - Parquet write-dependent tests now skip cleanly when no parquet engine is available locally.

## Verification
- `uv run pytest tests/test_loaders.py -q`
- `uv run pytest tests/ -q`
- `uv run ruff check pyrator/data/loaders.py pyrator/data/backends/pandas.py tests/test_loaders.py`
- `uv run mypy pyrator/` *(fails on pre-existing 47-error strict-typing backlog unrelated to this PR; no new mypy category introduced by these changes)*
