### PR TITLE
feat: add nominal Cohen's kappa metric

### DIFF
--- a/pyrator/ira/__init__.py
+++ b/pyrator/ira/__init__.py
@@ -1,6 +1,7 @@
 """Inter-Rater Agreement (IRA) metrics module."""
 
+from pyrator.ira.kappa import cohen_kappa
 from pyrator.ira.krippendorff import KrippendorffAlpha
 from pyrator.ira.semantic import SemanticDistanceFactory
 
-__all__ = ["KrippendorffAlpha", "SemanticDistanceFactory"]
+__all__ = ["KrippendorffAlpha", "SemanticDistanceFactory", "cohen_kappa"]

--- a/pyrator/ira/kappa.py
+++ b/pyrator/ira/kappa.py
@@ -1,0 +1,79 @@
+"""Kappa-family agreement metrics."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pyrator.types import FrameLike
+
+
+def cohen_kappa(
+    df: FrameLike,
+    *,
+    item_col: str,
+    rater_col: str,
+    label_col: str,
+) -> float:
+    """Compute nominal Cohen's kappa for exactly two raters.
+
+    Args:
+        df: Long-format annotation data.
+        item_col: Item/subject column.
+        rater_col: Rater/annotator column.
+        label_col: Nominal label column.
+
+    Returns:
+        Cohen's kappa value.
+
+    Raises:
+        ValueError: If input does not contain exactly two raters or has missing/duplicate ratings.
+    """
+    if hasattr(df, "to_pandas"):
+        frame = df.to_pandas()
+    else:
+        frame = df
+
+    for col in (item_col, rater_col, label_col):
+        if col not in frame.columns:
+            raise ValueError(f"Missing required column: {col}")
+
+    raters = sorted(frame[rater_col].dropna().unique())
+    if len(raters) != 2:
+        raise ValueError(
+            f"Cohen's kappa requires exactly two raters; found {len(raters)}: {raters}"
+        )
+
+    duplicate_counts = frame.groupby([item_col, rater_col]).size()
+    duplicate_pairs = duplicate_counts[duplicate_counts > 1]
+    if not duplicate_pairs.empty:
+        raise ValueError("Cohen's kappa requires one rating per (item, rater) pair.")
+
+    matrix = frame.pivot(index=item_col, columns=rater_col, values=label_col)
+    if matrix[raters].isna().any().any():
+        raise ValueError("Cohen's kappa cannot be computed with missing ratings per item.")
+
+    first, second = raters
+    labels = sorted(
+        np.unique(np.concatenate([matrix[first].to_numpy(), matrix[second].to_numpy()]))
+    )
+    confusion = (
+        matrix.groupby([first, second], observed=False).size().unstack(fill_value=0).reindex(
+            index=labels, columns=labels, fill_value=0
+        )
+    )
+
+    observed = confusion.to_numpy(dtype=float)
+    n_items = float(observed.sum())
+    if n_items == 0:
+        raise ValueError("Cohen's kappa requires at least one paired item.")
+
+    po = float(np.trace(observed) / n_items)
+    row_marginals = observed.sum(axis=1) / n_items
+    col_marginals = observed.sum(axis=0) / n_items
+    pe = float(np.dot(row_marginals, col_marginals))
+
+    denom = 1.0 - pe
+    if abs(denom) < 1e-12:
+        return 1.0 if abs(po - 1.0) < 1e-12 else 0.0
+
+    return float((po - pe) / denom)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,45 @@ def dag_with_redundant_edge() -> tuple[dict[str, dict[str, str]], list[tuple[str
 
 
 @pytest.fixture
+def cohen_nominal_data() -> pd.DataFrame:
+    """Canonical two-rater nominal dataset with expected Cohen's kappa = 0.4."""
+    rows: list[dict[str, str]] = []
+
+    # Confusion table:
+    #               rater_B
+    #           yes(30)  no(20)
+    # rater_A yes  20       5
+    #         no   10      15
+    # po = 0.7, pe = 0.5 => kappa = 0.4
+    item_id = 0
+    for _ in range(20):
+        item = f"item_{item_id}"
+        rows.append({"item": item, "rater": "A", "label": "yes"})
+        rows.append({"item": item, "rater": "B", "label": "yes"})
+        item_id += 1
+
+    for _ in range(5):
+        item = f"item_{item_id}"
+        rows.append({"item": item, "rater": "A", "label": "yes"})
+        rows.append({"item": item, "rater": "B", "label": "no"})
+        item_id += 1
+
+    for _ in range(10):
+        item = f"item_{item_id}"
+        rows.append({"item": item, "rater": "A", "label": "no"})
+        rows.append({"item": item, "rater": "B", "label": "yes"})
+        item_id += 1
+
+    for _ in range(15):
+        item = f"item_{item_id}"
+        rows.append({"item": item, "rater": "A", "label": "no"})
+        rows.append({"item": item, "rater": "B", "label": "no"})
+        item_id += 1
+
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
 def krippendorff_data():
     """
     Canonical 12-item dataset from Krippendorff (1980).

--- a/tests/test_kappa.py
+++ b/tests/test_kappa.py
@@ -1,0 +1,46 @@
+"""Tests for kappa-family agreement metrics."""
+
+import pandas as pd
+import pytest
+
+from pyrator.ira.kappa import cohen_kappa
+
+
+def test_cohen_kappa_nominal_reference_value(cohen_nominal_data: pd.DataFrame) -> None:
+    """Cohen's kappa should match the known reference value for this fixture."""
+    value = cohen_kappa(
+        cohen_nominal_data,
+        item_col="item",
+        rater_col="rater",
+        label_col="label",
+    )
+
+    assert value == pytest.approx(0.4, abs=1e-9)
+
+
+def test_cohen_kappa_requires_exactly_two_raters() -> None:
+    """Cohen's kappa must reject datasets with more than two raters."""
+    df = pd.DataFrame(
+        [
+            {"item": "i1", "rater": "A", "label": "x"},
+            {"item": "i1", "rater": "B", "label": "x"},
+            {"item": "i1", "rater": "C", "label": "y"},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="exactly two raters"):
+        cohen_kappa(df, item_col="item", rater_col="rater", label_col="label")
+
+
+def test_cohen_kappa_rejects_missing_ratings_per_item() -> None:
+    """Cohen's kappa requires both raters to annotate each item."""
+    df = pd.DataFrame(
+        [
+            {"item": "i1", "rater": "A", "label": "x"},
+            {"item": "i1", "rater": "B", "label": "x"},
+            {"item": "i2", "rater": "A", "label": "y"},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="missing ratings"):
+        cohen_kappa(df, item_col="item", rater_col="rater", label_col="label")


### PR DESCRIPTION
## Summary
Implements issue #16 by adding nominal Cohen's kappa support as the first split PR from umbrella #8.

### Changes
- Added `cohen_kappa(...)` in `pyrator/ira/kappa.py`.
- Exported `cohen_kappa` from `pyrator/ira/__init__.py`.
- Added canonical fixture `cohen_nominal_data` in `tests/conftest.py`.
- Added `tests/test_kappa.py` covering:
  - reference-value correctness (`kappa = 0.4`),
  - strict two-rater validation,
  - missing-per-item rating validation.

## Verification
- `uv run pytest tests/test_kappa.py -q`
- `uv run pytest tests/ -q`
- `uv run ruff check pyrator/ira/kappa.py pyrator/ira/__init__.py tests/test_kappa.py tests/conftest.py`
- `uv run mypy pyrator/ira/kappa.py pyrator/ira/__init__.py tests/test_kappa.py`
