### PR TITLE
feat: add strict Fleiss' kappa metric

### DIFF
--- a/pyrator/ira/__init__.py
+++ b/pyrator/ira/__init__.py
@@ -1,7 +1,7 @@
 """Inter-Rater Agreement (IRA) metrics module."""
 
-from pyrator.ira.kappa import cohen_kappa
+from pyrator.ira.kappa import cohen_kappa, fleiss_kappa
 from pyrator.ira.krippendorff import KrippendorffAlpha
 from pyrator.ira.semantic import SemanticDistanceFactory
 
-__all__ = ["KrippendorffAlpha", "SemanticDistanceFactory", "cohen_kappa"]
+__all__ = ["KrippendorffAlpha", "SemanticDistanceFactory", "cohen_kappa", "fleiss_kappa"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,32 @@ def cohen_nominal_data() -> pd.DataFrame:
 
 
 @pytest.fixture
+def fleiss_nominal_data() -> pd.DataFrame:
+    """Three-rater nominal fixture with expected Fleiss' kappa = 1/3."""
+    rows: list[dict[str, str]] = []
+
+    # Per-item category counts (A/B), n=3 raters each:
+    # item_1: (3,0)
+    # item_2: (2,1)
+    # item_3: (1,2)
+    # item_4: (0,3)
+    #
+    # Pbar = 2/3, PbarE = 1/2 => kappa = (2/3 - 1/2) / (1 - 1/2) = 1/3.
+    ratings = {
+        "item_1": ["A", "A", "A"],
+        "item_2": ["A", "A", "B"],
+        "item_3": ["A", "B", "B"],
+        "item_4": ["B", "B", "B"],
+    }
+    raters = ["R1", "R2", "R3"]
+    for item_id, labels in ratings.items():
+        for rater_id, label in zip(raters, labels, strict=True):
+            rows.append({"item": item_id, "rater": rater_id, "label": label})
+
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
 def krippendorff_data():
     """
     Canonical 12-item dataset from Krippendorff (1980).


### PR DESCRIPTION
## Summary
Implements issue #17 by adding strict Fleiss' kappa for many-rater nominal agreement.

### Changes
- Added `fleiss_kappa(...)` to `pyrator/ira/kappa.py`.
  - strict mode: requires equal number of ratings per item
  - validates one rating per `(item, rater)` pair
  - computes standard Fleiss agreement/expected terms from long-format data
- Exported `fleiss_kappa` from `pyrator/ira/__init__.py`.
- Added `fleiss_nominal_data` fixture in `tests/conftest.py`.
- Extended `tests/test_kappa.py` with:
  - reference-value test (`kappa = 1/3`),
  - strict unequal-ratings rejection,
  - duplicate `(item, rater)` rejection.

## Notes
Strict behavior is intentional for this PR. Auto-drop/incomplete-item handling can be added later as an opt-in enhancement.

## Verification
- `uv run pytest tests/test_kappa.py -q`
- `uv run pytest tests/ -q`
- `uv run ruff check pyrator/ira/kappa.py pyrator/ira/__init__.py tests/test_kappa.py tests/conftest.py`
- `uv run mypy pyrator/ira/kappa.py pyrator/ira/__init__.py tests/test_kappa.py`
