### PR TITLE
feat: add strict ICC 2/3 variant metrics

### DIFF
--- a/pyrator/ira/__init__.py
+++ b/pyrator/ira/__init__.py
@@ -1,7 +1,18 @@
 """Inter-Rater Agreement (IRA) metrics module."""
 
+from pyrator.ira.icc import icc_2_1, icc_2_k, icc_3_1, icc_3_k, intraclass_correlation
 from pyrator.ira.kappa import cohen_kappa, fleiss_kappa
 from pyrator.ira.krippendorff import KrippendorffAlpha
 from pyrator.ira.semantic import SemanticDistanceFactory
 
-__all__ = ["KrippendorffAlpha", "SemanticDistanceFactory", "cohen_kappa", "fleiss_kappa"]
+__all__ = [
+    "KrippendorffAlpha",
+    "SemanticDistanceFactory",
+    "cohen_kappa",
+    "fleiss_kappa",
+    "intraclass_correlation",
+    "icc_2_1",
+    "icc_2_k",
+    "icc_3_1",
+    "icc_3_k",
+]

--- a/pyrator/ira/icc.py
+++ b/pyrator/ira/icc.py
@@ -1,0 +1,224 @@
+"""Intraclass correlation coefficient (ICC) metrics for continuous agreement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+from numpy.typing import NDArray
+
+from pyrator.types import FrameLike
+
+ICCVariant = Literal["ICC2_1", "ICC2_k", "ICC3_1", "ICC3_k"]
+
+
+@dataclass(frozen=True)
+class _TwoWayMeanSquares:
+    """Container for two-way ANOVA mean squares used by ICC formulas."""
+
+    ms_rows: float
+    ms_cols: float
+    ms_error: float
+
+
+def intraclass_correlation(
+    df: FrameLike,
+    *,
+    item_col: str,
+    rater_col: str,
+    score_col: str,
+    variant: ICCVariant = "ICC2_1",
+) -> float:
+    """Compute Shrout/Fleiss-style two-way ICC variants for continuous ratings.
+
+    Supported variants:
+    - ``ICC2_1``: Two-way random effects, single rater/measurement.
+    - ``ICC2_k``: Two-way random effects, average of k raters/measurements.
+    - ``ICC3_1``: Two-way mixed effects, single rater/measurement.
+    - ``ICC3_k``: Two-way mixed effects, average of k raters/measurements.
+
+    Args:
+        df: Long-format annotation data.
+        item_col: Item/subject column.
+        rater_col: Rater/annotator column.
+        score_col: Continuous score column.
+        variant: ICC variant name.
+
+    Returns:
+        ICC value for the selected variant.
+
+    Raises:
+        ValueError: If inputs are malformed or selected variant is unsupported.
+    """
+    if hasattr(df, "to_pandas"):
+        frame = df.to_pandas()
+    else:
+        frame = df
+
+    for col in (item_col, rater_col, score_col):
+        if col not in frame.columns:
+            raise ValueError(f"Missing required column: {col}")
+
+    duplicate_counts = frame.groupby([item_col, rater_col]).size()
+    duplicate_pairs = duplicate_counts[duplicate_counts > 1]
+    if not duplicate_pairs.empty:
+        raise ValueError("ICC requires one rating per (item, rater) pair.")
+
+    matrix = frame.pivot(index=item_col, columns=rater_col, values=score_col)
+    if matrix.isna().any().any():
+        raise ValueError("ICC requires a complete item-by-rater matrix in strict mode.")
+
+    values = matrix.to_numpy()
+    try:
+        ratings = values.astype(float)
+    except (TypeError, ValueError) as error:
+        raise ValueError("ICC requires numeric score values.") from error
+
+    if not np.isfinite(ratings).all():
+        raise ValueError("ICC requires finite numeric score values.")
+
+    n_items, n_raters = ratings.shape
+    if n_items < 2:
+        raise ValueError("ICC requires at least two items.")
+    if n_raters < 2:
+        raise ValueError("ICC requires at least two raters.")
+
+    mean_squares = _compute_two_way_mean_squares(ratings)
+    return _compute_variant(
+        variant=variant,
+        mean_squares=mean_squares,
+        n_items=n_items,
+        n_raters=n_raters,
+    )
+
+
+def icc_2_1(
+    df: FrameLike,
+    *,
+    item_col: str,
+    rater_col: str,
+    score_col: str,
+) -> float:
+    """Compute ``ICC(2,1)`` (two-way random, single measurement)."""
+    return intraclass_correlation(
+        df,
+        item_col=item_col,
+        rater_col=rater_col,
+        score_col=score_col,
+        variant="ICC2_1",
+    )
+
+
+def icc_2_k(
+    df: FrameLike,
+    *,
+    item_col: str,
+    rater_col: str,
+    score_col: str,
+) -> float:
+    """Compute ``ICC(2,k)`` (two-way random, average measurement)."""
+    return intraclass_correlation(
+        df,
+        item_col=item_col,
+        rater_col=rater_col,
+        score_col=score_col,
+        variant="ICC2_k",
+    )
+
+
+def icc_3_1(
+    df: FrameLike,
+    *,
+    item_col: str,
+    rater_col: str,
+    score_col: str,
+) -> float:
+    """Compute ``ICC(3,1)`` (two-way mixed, single measurement)."""
+    return intraclass_correlation(
+        df,
+        item_col=item_col,
+        rater_col=rater_col,
+        score_col=score_col,
+        variant="ICC3_1",
+    )
+
+
+def icc_3_k(
+    df: FrameLike,
+    *,
+    item_col: str,
+    rater_col: str,
+    score_col: str,
+) -> float:
+    """Compute ``ICC(3,k)`` (two-way mixed, average measurement)."""
+    return intraclass_correlation(
+        df,
+        item_col=item_col,
+        rater_col=rater_col,
+        score_col=score_col,
+        variant="ICC3_k",
+    )
+
+
+def _compute_two_way_mean_squares(values: NDArray[np.float64]) -> _TwoWayMeanSquares:
+    """Compute two-way ANOVA mean squares for item and rater effects.
+
+    Notes:
+        Uses Shrout and Fleiss (1979) decomposition for fully crossed designs.
+    """
+    n_items, n_raters = values.shape
+    grand_mean = float(np.mean(values))
+    item_means = np.mean(values, axis=1)
+    rater_means = np.mean(values, axis=0)
+
+    ss_rows = float(n_raters * np.sum((item_means - grand_mean) ** 2))
+    ss_cols = float(n_items * np.sum((rater_means - grand_mean) ** 2))
+    ss_total = float(np.sum((values - grand_mean) ** 2))
+    ss_error = ss_total - ss_rows - ss_cols
+
+    # Guard against tiny negative residuals from floating-point cancellation.
+    if ss_error < 0.0 and abs(ss_error) < 1e-12:
+        ss_error = 0.0
+
+    ms_rows = ss_rows / float(n_items - 1)
+    ms_cols = ss_cols / float(n_raters - 1)
+    ms_error = ss_error / float((n_items - 1) * (n_raters - 1))
+
+    return _TwoWayMeanSquares(ms_rows=ms_rows, ms_cols=ms_cols, ms_error=ms_error)
+
+
+def _compute_variant(
+    *,
+    variant: ICCVariant,
+    mean_squares: _TwoWayMeanSquares,
+    n_items: int,
+    n_raters: int,
+) -> float:
+    """Map supported ICC variants to their Shrout/Fleiss formulas."""
+    msr = mean_squares.ms_rows
+    msc = mean_squares.ms_cols
+    mse = mean_squares.ms_error
+
+    numerator = msr - mse
+    n_items_f = float(n_items)
+    n_raters_f = float(n_raters)
+
+    if variant == "ICC2_1":
+        denominator = msr + (n_raters_f - 1.0) * mse + (n_raters_f * (msc - mse) / n_items_f)
+    elif variant == "ICC2_k":
+        denominator = msr + ((msc - mse) / n_items_f)
+    elif variant == "ICC3_1":
+        denominator = msr + (n_raters_f - 1.0) * mse
+    elif variant == "ICC3_k":
+        denominator = msr
+    else:
+        raise ValueError(
+            f"Unsupported ICC variant: {variant}. "
+            "Supported variants: ICC2_1, ICC2_k, ICC3_1, ICC3_k."
+        )
+
+    if abs(denominator) < 1e-12:
+        raise ValueError(f"ICC variant {variant} is undefined because its denominator is zero.")
+
+    return float(numerator / denominator)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def crows_pairs_path() -> str:
 
 
 @pytest.fixture
-def simple_ontology():
+def simple_ontology() -> Ontology:
     r"""
     A diamond graph for testing semantic distances.
 
@@ -175,7 +175,31 @@ def fleiss_nominal_data() -> pd.DataFrame:
 
 
 @pytest.fixture
-def krippendorff_data():
+def icc_continuous_data() -> pd.DataFrame:
+    """Continuous-rating fixture with deterministic ICC reference outputs."""
+    rows: list[dict[str, str | float]] = []
+
+    # Ratings matrix (items x raters):
+    # i1: [9, 2, 5]
+    # i2: [6, 1, 3]
+    # i3: [8, 4, 6]
+    # i4: [7, 1, 2]
+    ratings = {
+        "i1": {"A": 9.0, "B": 2.0, "C": 5.0},
+        "i2": {"A": 6.0, "B": 1.0, "C": 3.0},
+        "i3": {"A": 8.0, "B": 4.0, "C": 6.0},
+        "i4": {"A": 7.0, "B": 1.0, "C": 2.0},
+    }
+
+    for item_id, per_rater in ratings.items():
+        for rater_id, score in per_rater.items():
+            rows.append({"item": item_id, "rater": rater_id, "score": score})
+
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
+def krippendorff_data() -> pd.DataFrame:
     """
     Canonical 12-item dataset from Krippendorff (1980).
     Expected Alpha (Nominal) approx 0.375.

--- a/tests/test_icc.py
+++ b/tests/test_icc.py
@@ -1,0 +1,154 @@
+"""Tests for intraclass correlation (ICC) agreement metrics."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pandas as pd
+import pytest
+
+from pyrator.ira.icc import (
+    ICCVariant,
+    icc_2_1,
+    icc_2_k,
+    icc_3_1,
+    icc_3_k,
+    intraclass_correlation,
+)
+
+
+@pytest.mark.parametrize(
+    ("variant", "expected"),
+    [
+        ("ICC2_1", 0.16806722689075623),
+        ("ICC2_k", 0.37735849056603765),
+        ("ICC3_1", 0.7142857142857142),
+        ("ICC3_k", 0.8823529411764705),
+    ],
+)
+def test_intraclass_correlation_reference_values(
+    icc_continuous_data: pd.DataFrame,
+    variant: ICCVariant,
+    expected: float,
+) -> None:
+    """Each supported ICC variant should match known reference values."""
+    value = intraclass_correlation(
+        icc_continuous_data,
+        item_col="item",
+        rater_col="rater",
+        score_col="score",
+        variant=variant,
+    )
+
+    assert value == pytest.approx(expected, abs=1e-12)
+
+
+def test_icc_wrapper_functions_match_dispatch(icc_continuous_data: pd.DataFrame) -> None:
+    """Wrapper functions should match dispatcher outputs for each variant."""
+    assert icc_2_1(
+        icc_continuous_data, item_col="item", rater_col="rater", score_col="score"
+    ) == pytest.approx(
+        intraclass_correlation(
+            icc_continuous_data,
+            item_col="item",
+            rater_col="rater",
+            score_col="score",
+            variant="ICC2_1",
+        ),
+        abs=1e-12,
+    )
+    assert icc_2_k(
+        icc_continuous_data, item_col="item", rater_col="rater", score_col="score"
+    ) == pytest.approx(
+        intraclass_correlation(
+            icc_continuous_data,
+            item_col="item",
+            rater_col="rater",
+            score_col="score",
+            variant="ICC2_k",
+        ),
+        abs=1e-12,
+    )
+    assert icc_3_1(
+        icc_continuous_data, item_col="item", rater_col="rater", score_col="score"
+    ) == pytest.approx(
+        intraclass_correlation(
+            icc_continuous_data,
+            item_col="item",
+            rater_col="rater",
+            score_col="score",
+            variant="ICC3_1",
+        ),
+        abs=1e-12,
+    )
+    assert icc_3_k(
+        icc_continuous_data, item_col="item", rater_col="rater", score_col="score"
+    ) == pytest.approx(
+        intraclass_correlation(
+            icc_continuous_data,
+            item_col="item",
+            rater_col="rater",
+            score_col="score",
+            variant="ICC3_k",
+        ),
+        abs=1e-12,
+    )
+
+
+def test_intraclass_correlation_rejects_missing_item_rater_cells() -> None:
+    """ICC should require a complete item-by-rater matrix in strict mode."""
+    df = pd.DataFrame(
+        [
+            {"item": "i1", "rater": "A", "score": 1.0},
+            {"item": "i1", "rater": "B", "score": 2.0},
+            {"item": "i2", "rater": "A", "score": 3.0},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="complete item-by-rater matrix"):
+        intraclass_correlation(df, item_col="item", rater_col="rater", score_col="score")
+
+
+def test_intraclass_correlation_rejects_duplicate_item_rater_pairs() -> None:
+    """ICC should reject duplicate (item, rater) observations."""
+    df = pd.DataFrame(
+        [
+            {"item": "i1", "rater": "A", "score": 1.0},
+            {"item": "i1", "rater": "A", "score": 1.5},
+            {"item": "i1", "rater": "B", "score": 2.0},
+            {"item": "i2", "rater": "A", "score": 3.0},
+            {"item": "i2", "rater": "B", "score": 4.0},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="one rating per \\(item, rater\\) pair"):
+        intraclass_correlation(df, item_col="item", rater_col="rater", score_col="score")
+
+
+def test_intraclass_correlation_rejects_non_numeric_scores() -> None:
+    """ICC should reject non-numeric score columns."""
+    df = pd.DataFrame(
+        [
+            {"item": "i1", "rater": "A", "score": "high"},
+            {"item": "i1", "rater": "B", "score": "low"},
+            {"item": "i2", "rater": "A", "score": "mid"},
+            {"item": "i2", "rater": "B", "score": "mid"},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="numeric"):
+        intraclass_correlation(df, item_col="item", rater_col="rater", score_col="score")
+
+
+def test_intraclass_correlation_rejects_unknown_variant(
+    icc_continuous_data: pd.DataFrame,
+) -> None:
+    """Only the explicitly supported four ICC variants should be accepted."""
+    with pytest.raises(ValueError, match="Unsupported ICC variant"):
+        intraclass_correlation(
+            icc_continuous_data,
+            item_col="item",
+            rater_col="rater",
+            score_col="score",
+            variant=cast("ICCVariant", "ICC1_1"),
+        )


### PR DESCRIPTION
## Summary
- add strict continuous-agreement ICC support in `pyrator.ira` for `ICC(2,1)`, `ICC(2,k)`, `ICC(3,1)`, and `ICC(3,k)`
- add public dispatcher `intraclass_correlation(...)` plus explicit wrappers: `icc_2_1`, `icc_2_k`, `icc_3_1`, `icc_3_k`
- add deterministic fixture and tests for all four variants plus strict input validation cases

## Design Notes
- strict-by-default behavior is enforced (complete item×rater matrix required)
- formulas follow Shrout/Fleiss two-way ANOVA mean-square decomposition
- malformed inputs fail fast with explicit `ValueError` messages

## Test Plan
- [x] `uv run pytest tests/test_icc.py -q`
- [x] `uv run ruff check pyrator/ira/icc.py pyrator/ira/__init__.py tests/test_icc.py tests/conftest.py`
- [x] `uv run mypy pyrator/ira/icc.py pyrator/ira/__init__.py tests/test_icc.py tests/conftest.py`
- [x] `uv run pytest tests/ -q`

Closes #18
