### PR TITLE
feat: add AnnotatorModel facade and ModelResults API

### DIFF
--- a/pyrator/__init__.py
+++ b/pyrator/__init__.py
@@ -1,0 +1,5 @@
+"""Public package exports."""
+
+from pyrator.api import AnnotatorModel, ModelResults
+
+__all__ = ["AnnotatorModel", "ModelResults"]

--- a/pyrator/api.py
+++ b/pyrator/api.py
@@ -1,0 +1,232 @@
+"""High-level user facade for agreement analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, cast
+
+import pandas as pd
+
+from pyrator.ira.krippendorff import KrippendorffAlpha
+from pyrator.ira.semantic import SemanticDistanceFactory
+from pyrator.ontology.core import Ontology
+from pyrator.types import FrameLike
+
+AgreementMode = Literal["nominal", "semantic"]
+SemanticMetric = Literal["path", "lin", "resnik_norm"]
+
+
+@dataclass(slots=True)
+class ModelResults:
+    """Structured results produced by ``AnnotatorModel.fit``."""
+
+    alpha: float
+    mode: AgreementMode
+    metric: SemanticMetric | None
+    _hard_items: pd.DataFrame
+    _annotator_profiles: pd.DataFrame
+    _consensus_labels: pd.Series
+
+    def get_hard_items(self, top_n: int = 10) -> pd.DataFrame:
+        """Return the highest-disagreement items."""
+        if top_n <= 0:
+            raise ValueError("top_n must be positive.")
+        return self._hard_items.head(top_n).copy()
+
+    def get_annotator_profiles(self) -> pd.DataFrame:
+        """Return per-annotator agreement summaries."""
+        return self._annotator_profiles.copy()
+
+    def get_consensus_labels(self) -> pd.Series:
+        """Return deterministic item-level consensus labels."""
+        return self._consensus_labels.copy()
+
+
+class AnnotatorModel:
+    """Thin facade around current Krippendorff and ontology-semantic components."""
+
+    _SUPPORTED_SEMANTIC_METRICS: set[str] = {"path", "lin", "resnik_norm"}
+
+    def __init__(
+        self,
+        ontology: Ontology | None = None,
+        *,
+        strategy: str = "auto",
+        mode: str = "nominal",
+        metric: str = "path",
+        random_state: int | None = 0,
+        item_col: str = "item_id",
+        rater_col: str = "annotator_id",
+        label_col: str = "label_id",
+    ):
+        self.ontology = ontology
+        self.strategy = strategy
+        self.mode = self._validate_mode(mode)
+        self.metric = self._validate_semantic_metric(metric)
+        self.random_state = random_state
+        self.item_col = item_col
+        self.rater_col = rater_col
+        self.label_col = label_col
+
+    def fit(self, data: FrameLike) -> ModelResults:
+        """Fit agreement analysis and return structured results."""
+        normalized = self._normalize_input_frame(self._to_pandas_frame(data))
+
+        ka = KrippendorffAlpha(
+            normalized,
+            item_col="item_id",
+            rater_col="annotator_id",
+            label_col="label_id",
+        )
+
+        metric_used: SemanticMetric | None = None
+        if self.mode == "nominal":
+            alpha = ka.calculate(metric="nominal")
+        else:
+            if self.ontology is None:
+                raise ValueError("Semantic mode requires an ontology.")
+            metric_used = self.metric
+            labels = sorted(normalized["label_id"].unique(), key=lambda value: str(value))
+            distance_matrix = SemanticDistanceFactory(self.ontology).compute_distance_matrix(
+                labels,
+                metric=metric_used,
+            )
+            alpha = ka.calculate(metric="custom", distance_matrix=distance_matrix)
+
+        consensus = self._build_consensus_labels(normalized)
+        hard_items = self._build_hard_items(normalized, consensus)
+        profiles = self._build_annotator_profiles(normalized, consensus)
+
+        return ModelResults(
+            alpha=float(alpha),
+            mode=self.mode,
+            metric=metric_used,
+            _hard_items=hard_items,
+            _annotator_profiles=profiles,
+            _consensus_labels=consensus,
+        )
+
+    def _normalize_input_frame(self, frame: pd.DataFrame) -> pd.DataFrame:
+        """Validate and normalize input columns to canonical internal names."""
+        for col in (self.item_col, self.rater_col, self.label_col):
+            if col not in frame.columns:
+                raise ValueError(f"Missing required column: {col}")
+
+        normalized = frame[[self.item_col, self.rater_col, self.label_col]].rename(
+            columns={
+                self.item_col: "item_id",
+                self.rater_col: "annotator_id",
+                self.label_col: "label_id",
+            }
+        )
+
+        if normalized.empty:
+            raise ValueError("AnnotatorModel.fit requires at least one annotation row.")
+
+        if normalized[["item_id", "annotator_id", "label_id"]].isna().any().any():
+            raise ValueError("Input contains nulls in required item/rater/label columns.")
+
+        duplicate_counts = normalized.groupby(["item_id", "annotator_id"]).size()
+        duplicate_pairs = duplicate_counts[duplicate_counts > 1]
+        if not duplicate_pairs.empty:
+            raise ValueError("AnnotatorModel.fit requires one rating per (item, rater) pair.")
+
+        return normalized
+
+    def _to_pandas_frame(self, data: FrameLike) -> pd.DataFrame:
+        """Convert supported frame-like inputs to pandas DataFrame."""
+        frame = data.to_pandas() if hasattr(data, "to_pandas") else data
+        if not isinstance(frame, pd.DataFrame):
+            raise ValueError("AnnotatorModel.fit expects a pandas-compatible frame-like input.")
+        return frame
+
+    def _validate_mode(self, mode: str) -> AgreementMode:
+        if mode not in {"nominal", "semantic"}:
+            raise ValueError("Unsupported mode. Supported modes: nominal, semantic.")
+        return cast("AgreementMode", mode)
+
+    def _validate_semantic_metric(self, metric: str) -> SemanticMetric:
+        if metric not in self._SUPPORTED_SEMANTIC_METRICS:
+            raise ValueError(
+                "Unsupported semantic metric. Supported metrics: path, lin, resnik_norm."
+            )
+        return cast("SemanticMetric", metric)
+
+    def _build_consensus_labels(self, normalized: pd.DataFrame) -> pd.Series:
+        """Compute deterministic item-level consensus labels."""
+        consensus = normalized.groupby("item_id", sort=True)["label_id"].apply(
+            self._deterministic_mode
+        )
+        consensus.name = "consensus_label"
+        return consensus
+
+    def _build_hard_items(self, normalized: pd.DataFrame, consensus: pd.Series) -> pd.DataFrame:
+        """Compute item hardness using disagreement rate with deterministic ordering."""
+        with_consensus = normalized.merge(
+            consensus.rename("consensus_label"),
+            left_on="item_id",
+            right_index=True,
+            how="left",
+            validate="many_to_one",
+        )
+        with_consensus["is_disagreement"] = (
+            with_consensus["label_id"] != with_consensus["consensus_label"]
+        )
+
+        hard = (
+            with_consensus.groupby("item_id", sort=True)
+            .agg(
+                consensus_label=("consensus_label", "first"),
+                n_ratings=("label_id", "size"),
+                disagreement_rate=("is_disagreement", "mean"),
+            )
+            .reset_index()
+        )
+        hard = hard.sort_values(
+            by=["disagreement_rate", "n_ratings", "item_id"],
+            ascending=[False, False, True],
+            kind="mergesort",
+        ).reset_index(drop=True)
+        return hard
+
+    def _build_annotator_profiles(
+        self,
+        normalized: pd.DataFrame,
+        consensus: pd.Series,
+    ) -> pd.DataFrame:
+        """Compute per-annotator agreement profiles against consensus labels."""
+        with_consensus = normalized.merge(
+            consensus.rename("consensus_label"),
+            left_on="item_id",
+            right_index=True,
+            how="left",
+            validate="many_to_one",
+        )
+        with_consensus["is_disagreement"] = (
+            with_consensus["label_id"] != with_consensus["consensus_label"]
+        )
+
+        profiles = (
+            with_consensus.groupby("annotator_id", sort=True)
+            .agg(
+                n_items=("item_id", "size"),
+                disagreement_rate=("is_disagreement", "mean"),
+            )
+            .reset_index()
+        )
+        profiles["agreement_rate"] = 1.0 - profiles["disagreement_rate"]
+        profiles = profiles[["annotator_id", "n_items", "agreement_rate", "disagreement_rate"]]
+        profiles = profiles.sort_values(
+            by=["agreement_rate", "annotator_id"],
+            ascending=[False, True],
+            kind="mergesort",
+        ).reset_index(drop=True)
+        return profiles
+
+    @staticmethod
+    def _deterministic_mode(values: pd.Series) -> object:
+        """Return mode with string-ordered tie-break for deterministic outputs."""
+        counts = values.value_counts()
+        max_count = counts.max()
+        candidates = counts[counts == max_count].index.tolist()
+        return sorted(candidates, key=lambda value: str(value))[0]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,180 @@
+"""Tests for the high-level AnnotatorModel facade."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from pyrator.api import AnnotatorModel, ModelResults
+from pyrator.ontology.core import Ontology
+
+
+def test_annotator_model_nominal_fit_with_configurable_columns() -> None:
+    """Nominal fit should work with non-canonical column names."""
+    df = pd.DataFrame(
+        [
+            {"item": "i1", "rater": "A", "label": "x"},
+            {"item": "i1", "rater": "B", "label": "x"},
+            {"item": "i2", "rater": "A", "label": "y"},
+            {"item": "i2", "rater": "B", "label": "y"},
+            {"item": "i3", "rater": "A", "label": "x"},
+            {"item": "i3", "rater": "B", "label": "y"},
+        ]
+    )
+
+    model = AnnotatorModel(
+        mode="nominal",
+        item_col="item",
+        rater_col="rater",
+        label_col="label",
+    )
+    results = model.fit(df)
+
+    assert isinstance(results, ModelResults)
+    assert results.mode == "nominal"
+    assert results.metric is None
+    assert -1.0 <= results.alpha <= 1.0
+
+    consensus = results.get_consensus_labels()
+    assert list(consensus.index) == ["i1", "i2", "i3"]
+    assert list(consensus.values) == ["x", "y", "x"]
+
+    hard_items = results.get_hard_items(top_n=2)
+    assert list(hard_items["item_id"]) == ["i3", "i1"]
+    assert hard_items.iloc[0]["disagreement_rate"] == pytest.approx(0.5, abs=1e-12)
+
+    profiles = results.get_annotator_profiles()
+    assert set(profiles["annotator_id"].tolist()) == {"A", "B"}
+    agreement_a = profiles.loc[profiles["annotator_id"] == "A", "agreement_rate"].item()
+    agreement_b = profiles.loc[profiles["annotator_id"] == "B", "agreement_rate"].item()
+    assert agreement_a == pytest.approx(1.0, abs=1e-12)
+    assert agreement_b == pytest.approx(2.0 / 3.0, abs=1e-12)
+
+
+def test_annotator_model_nominal_fit_with_canonical_defaults() -> None:
+    """Default canonical columns should work without explicit mapping."""
+    df = pd.DataFrame(
+        [
+            {"item_id": "i1", "annotator_id": "A", "label_id": "yes"},
+            {"item_id": "i1", "annotator_id": "B", "label_id": "yes"},
+            {"item_id": "i2", "annotator_id": "A", "label_id": "no"},
+            {"item_id": "i2", "annotator_id": "B", "label_id": "yes"},
+        ]
+    )
+
+    results = AnnotatorModel(mode="nominal").fit(df)
+    assert isinstance(results, ModelResults)
+    assert len(results.get_consensus_labels()) == 2
+
+
+@pytest.mark.parametrize(
+    ("metric", "expected_alpha"),
+    [
+        ("path", -0.2857142857142856),
+        ("lin", -0.19999999999999996),
+        ("resnik_norm", 1.0),
+    ],
+)
+def test_annotator_model_semantic_fit_with_supported_metrics(
+    simple_ontology: Ontology,
+    metric: str,
+    expected_alpha: float,
+) -> None:
+    """Semantic mode should support path/lin/resnik_norm with strict metric validation."""
+    df = pd.DataFrame(
+        [
+            {"item": "i1", "rater": "r1", "label": "A"},
+            {"item": "i1", "rater": "r2", "label": "C"},
+            {"item": "i2", "rater": "r1", "label": "A"},
+            {"item": "i2", "rater": "r2", "label": "B"},
+        ]
+    )
+    model = AnnotatorModel(
+        ontology=simple_ontology,
+        mode="semantic",
+        metric=metric,
+        item_col="item",
+        rater_col="rater",
+        label_col="label",
+    )
+
+    results = model.fit(df)
+    assert results.mode == "semantic"
+    assert results.metric == metric
+    assert results.alpha == pytest.approx(expected_alpha, abs=1e-12)
+
+
+def test_annotator_model_semantic_requires_ontology() -> None:
+    """Semantic mode should fail fast if ontology is not provided."""
+    df = pd.DataFrame(
+        [
+            {"item": "i1", "rater": "A", "label": "A"},
+            {"item": "i1", "rater": "B", "label": "B"},
+        ]
+    )
+    model = AnnotatorModel(
+        mode="semantic",
+        metric="path",
+        item_col="item",
+        rater_col="rater",
+        label_col="label",
+    )
+
+    with pytest.raises(ValueError, match="requires an ontology"):
+        model.fit(df)
+
+
+def test_annotator_model_rejects_unknown_semantic_metric(simple_ontology: Ontology) -> None:
+    """Only path/lin/resnik_norm should be accepted in semantic mode."""
+    with pytest.raises(ValueError, match="Unsupported semantic metric"):
+        AnnotatorModel(ontology=simple_ontology, mode="semantic", metric="lca")
+
+
+def test_annotator_model_rejects_missing_required_columns() -> None:
+    """Configured item/rater/label columns are required."""
+    df = pd.DataFrame(
+        [
+            {"item": "i1", "rater": "A", "label": "x"},
+            {"item": "i1", "rater": "B", "label": "x"},
+        ]
+    )
+
+    model = AnnotatorModel(mode="nominal")
+    with pytest.raises(ValueError, match="Missing required column"):
+        model.fit(df)
+
+
+def test_annotator_model_rejects_duplicate_item_rater_pairs() -> None:
+    """Strict mode requires exactly one rating per (item, rater) pair."""
+    df = pd.DataFrame(
+        [
+            {"item": "i1", "rater": "A", "label": "x"},
+            {"item": "i1", "rater": "A", "label": "y"},
+            {"item": "i1", "rater": "B", "label": "x"},
+        ]
+    )
+    model = AnnotatorModel(
+        mode="nominal",
+        item_col="item",
+        rater_col="rater",
+        label_col="label",
+    )
+
+    with pytest.raises(ValueError, match="one rating per \\(item, rater\\) pair"):
+        model.fit(df)
+
+
+def test_model_results_get_hard_items_validates_top_n() -> None:
+    """ModelResults.get_hard_items should reject non-positive top_n values."""
+    df = pd.DataFrame(
+        [
+            {"item_id": "i1", "annotator_id": "A", "label_id": "x"},
+            {"item_id": "i1", "annotator_id": "B", "label_id": "x"},
+            {"item_id": "i2", "annotator_id": "A", "label_id": "y"},
+            {"item_id": "i2", "annotator_id": "B", "label_id": "x"},
+        ]
+    )
+    results = AnnotatorModel(mode="nominal").fit(df)
+
+    with pytest.raises(ValueError, match="top_n must be positive"):
+        results.get_hard_items(top_n=0)


### PR DESCRIPTION
## Summary
- add `pyrator.api` with a thin `AnnotatorModel` facade and minimal functional `ModelResults`
- support both nominal and ontology-backed semantic alpha via existing IRA components
- add strict validation and configurable input column mappings (canonical defaults + custom names)

## Details
- `AnnotatorModel` supports:
  - `mode="nominal"`
  - `mode="semantic"` with strict semantic metric validation: `path`, `lin`, `resnik_norm`
- strict checks for:
  - required columns
  - null values in required columns
  - one rating per `(item, rater)` pair
  - semantic mode requires `ontology`
- `ModelResults` accessors implemented:
  - `get_hard_items(top_n=...)`
  - `get_annotator_profiles()`
  - `get_consensus_labels()`
- deterministic behavior:
  - consensus tie-break by lexical order
  - stable hard-item sorting

## Test Plan
- [x] `uv run pytest tests/test_api.py -q` (RED then GREEN)
- [x] `uv run ruff check pyrator/api.py pyrator/__init__.py tests/test_api.py`
- [x] `uv run mypy pyrator/api.py pyrator/__init__.py tests/test_api.py`
- [x] `uv run pytest tests/ -q`

Closes #9
