### PR TITLE
feat(types): add require_non_none helper utility

### DIFF
--- a/pyrator/drift/monitor.py
+++ b/pyrator/drift/monitor.py
@@ -12,6 +12,7 @@ from pyrator.drift.jsd import jsd
 from pyrator.drift.mmd import mmd
 from pyrator.drift.psi import psi
 from pyrator.drift.wasserstein import w1
+from pyrator.types import require_non_none
 
 
 @dataclass
@@ -100,10 +101,10 @@ class Monitor:
         func, config = dispatch_entry
 
         for param, attr in config["required"].items():
-            if getattr(self.config, attr) is None:
-                raise ValueError(
-                    f"{self.config.metric.capitalize()} monitor requires '{param}' parameter"
-                )
+            require_non_none(
+                getattr(self.config, attr),
+                f"{self.config.metric.capitalize()} monitor requires '{param}' parameter",
+            )
 
         kwargs: dict[str, Any] = {"data": data, "window_col": self.config.window_col}
         for param in config["params"]:

--- a/pyrator/types.py
+++ b/pyrator/types.py
@@ -3,13 +3,23 @@
 from __future__ import annotations
 
 from numbers import Integral, Real
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, TypeVar, runtime_checkable
 
 if TYPE_CHECKING:
     # Kept in TYPE_CHECKING to avoid a runtime dependency on ibis.
     from ibis.expr.types import Expr as IbisExpr
 else:
     IbisExpr = object
+
+
+T = TypeVar("T")
+
+
+def require_non_none(value: T | None, msg: str = "unexpected None") -> T:
+    """Assert that a value is not None, raising ValueError if it is."""
+    if value is None:
+        raise ValueError(msg)
+    return value
 
 
 @runtime_checkable


### PR DESCRIPTION
## Summary
Add `require_non_none()` helper to reduce repetitive `if x is None: raise ValueError` patterns.

## Changes
- Added `require_non_none(value, msg)` to `pyrator/types.py`
- Used in `Monitor.execute()` to simplify required parameter validation

## Example Usage
```python
from pyrator.types import require_non_none

def foo(x: int | None):
    x = require_non_none(x, "x is required")
    # x is now int, not int | None
```